### PR TITLE
[Refactor] Create a base class for all TMX-related exceptions

### DIFF
--- a/hypatia/game.py
+++ b/hypatia/game.py
@@ -42,7 +42,17 @@ from hypatia import constants
 from hypatia import controllers
 
 
-class TMXMissingPlayerStartPosition(Exception):
+class TMXException(Exception):
+    """Base class for all exceptions related to TMX.
+
+    See Also:
+        :class:`TMX`
+
+    """
+    pass
+
+
+class TMXMissingPlayerStartPosition(TMXException):
     """TMX file parsed does not have a player start
     position, which is required to create scenes.
 
@@ -56,7 +66,7 @@ class TMXMissingPlayerStartPosition(Exception):
         super(TMXMissingPlayerStartPosition, self).__init__(message)
 
 
-class TMXTooManyTilesheets(Exception):
+class TMXTooManyTilesheets(TMXException):
     """A TMX file was attempted to be imported through
     `TileMap.from_tmx()`, but the TMX defined more than
     one tilesheet. This is a feature Hypatia does not
@@ -79,7 +89,7 @@ class TMXTooManyTilesheets(Exception):
         super(TMXTooManyTilesheets, self).__init__(message)
 
 
-class TMXVersionUnsupported(Exception):
+class TMXVersionUnsupported(TMXException):
     """Attempted to create a TileMap from a TMX map, but
     the TMX map version is unsupported.
 
@@ -103,7 +113,7 @@ class TMXVersionUnsupported(Exception):
         self.map_version = map_version
 
 
-class TMXLayersNotCSV(Exception):
+class TMXLayersNotCSV(TMXException):
     """The data encoding used for layers during Tilemap.from_tmx()
     is not supported. Only CSV is supported.
 


### PR DESCRIPTION
Hypatia defines a number of exceptions related to the `TMX` class,
e.g. `TMXVersionUnsupported`.  All of these exceptions are children of
Python's fundamental `Exception` class.  This fact creates a challenge
for handling TMX-related errors.  If we expect the possibility of a
specific exception, such as `TMXLayersNotCSV`, then we can simply
write the following:

    try:
        # ...
    except TMXLayersNotCSV:
        # ...

We may have code that could potentially raise two exceptions, and in
that situation we could write this:

    try:
        # ...
    except (TMXLayersNotCSV, TMXVersionUnsupported):
        # ...

However, we run into a number of problems whenever we write code where
we want to handle multiple TMX-related exceptions.  Let's say we are
writing code that needs to handle any `TMX...` exception.

    try:
        # Code which may raise any `TMX...` exception
    except ???:
        # ...

What do we write for the `???` part of the code above?  We could list
every TMX-related exception like so:

    try:
        # ...
    except (TMXLayersNotCSV,
            TMXVersionUnsupported,
            TMXMissingPlayerStartPosition,
            TMXTooManyTilesheets):
        # ...

Arguably this code is ugly, and we could rewrite it to use multiple
`except` statements.  But the real problem is that if we ever created
a new TMX-related exception we must remember to come back and modify
the above code appropriately to include the new exception.  This would
be easy to forget or overlook.  To describe the problem another way,
we have no safe, simple way to catch all exceptions related to TMX.
Because they all inherit from `Exception` we could write...

    except Exception: # ...

...but then we would catch not only all TMX-related exceptions, but
all exceptions, period.  This is undesirable because our code would
silence all potential errors that have nothing to do with TMX.

This patch addresses all of these problems by creating a new exception
called `TMXException`.  This new class becomes the parent of all
existing TMX-related exceptions, e.g. `TMXVersionUnsupported` is now a
child of `TMXException`.  Now we can return to the problem above where
we wanted to deal with code which could raise any number of exceptions
related to TMX.  By using the new exception in this patch we can
structure our code like so:

    try:
        # Code which may raise any `TMX...` exception
    except TMXException:
        # ...

The benefits:

1. We do not need to rewrite the code if we create a new exception
   related to TMX.

2. We will not accidentally catch or silence errors which have nothing
   to do with TMX, e.g. `ArithmeticError`.

Note that this patch only defines `TMXException` and modifies existing
exceptions to inherit from it.  We have no try-except statements which
catch any exceptions related to TMX.  And therefore we have no such
statements to change with this patch.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>