### PR TITLE
[Feature] Use the $PAGER environment variable in test.sh

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -47,13 +47,14 @@
 
 PIP="pip${HYPATIA_PYTHON_VERSION}"
 PYTHON="python${HYPATIA_PYTHON_VERSION}"
+PAGER="${PAGER:=more}"
 
 "$PIP" uninstall hypatia_engine -y
 pandoc README.md -t rst -o PKG-INFO
 "$PYTHON" setup.py check -r -s
 "$PIP" install --user --no-cache-dir .
 rm PKG-INFO
-py.test tests --pep8 --doctest-modules hypatia -v --cov-report term-missing --cov=hypatia | more
+py.test tests --pep8 --doctest-modules hypatia -v --cov-report term-missing --cov=hypatia | "$PAGER"
 cd demo
 "$PYTHON" game.py
 cd ..


### PR DESCRIPTION
Most POSIX-based platforms make use of the `$PAGER` environment
variable.  For example, the `man` command uses the program named by
`$PAGER` to display manual pages.

The `test.sh` script always uses `more`.  This patch changes the
script so that it will use the uesr's personal `$PAGER` if it is set.
And if not set the script defaults to using `more` like before.

Signed-off-by: Eric James Michael Ritz <ejmr@plutono.com>